### PR TITLE
Issue #00 fix: removing jessie-updates from docker image

### DIFF
--- a/Dockerfile.Build
+++ b/Dockerfile.Build
@@ -1,6 +1,7 @@
 #Dockerfile for the player setup
 FROM node:8.11.0
 MAINTAINER "Rajesh Rajendran <rajesh.r@optit.co>"
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils \
 && apt-get install -y --force-yes \ 
  python python-dev autoconf g++ make nasm bzip2


### PR DESCRIPTION
removing jessie-updates repo url from source list, since it is not supported/available now.