### PR TITLE
Issue #SB-17663 fix: License details : "For details" text should not …

### DIFF
--- a/src/app/client/src/app/modules/learn/components/course-consumption/course-player/course-player.component.html
+++ b/src/app/client/src/app/modules/learn/components/course-consumption/course-player/course-player.component.html
@@ -80,7 +80,7 @@
                                 <p class="mb-5" *ngIf="courseHierarchy && courseHierarchy.licenseDetails && courseHierarchy.licenseDetails['name']">
                                     <span>{{resourceService.frmelmnts.lbl.licenseTerms}}:</span>
                                     {{courseHierarchy.licenseDetails['name']}} <br>
-                                    <span class="licenseTag">
+                                    <span class="licenseTag" *ngIf="courseHierarchy && courseHierarchy.licenseDetails && courseHierarchy.licenseDetails['url']">
                                         For details - <a href="{{courseHierarchy.licenseDetails['url']}}" target="_blank">{{courseHierarchy.licenseDetails['url']}}</a>
                                     </span>
                                  </p>


### PR DESCRIPTION
…be displayed when the user chooses standard youtube license as the value during creation