### PR TITLE
Updated the file to fix the JIRA issue SB-17901

### DIFF
--- a/src/app/client/src/app/plugins/profile/components/update-contact-details/update-contact-details.component.ts
+++ b/src/app/client/src/app/plugins/profile/components/update-contact-details/update-contact-details.component.ts
@@ -114,10 +114,13 @@ export class UpdateContactDetailsComponent implements OnInit, OnDestroy {
     let contactValue = '';
     contactTypeControl.valueChanges.subscribe(
       (data: string) => {
+        contactValue = '';
         if (contactTypeControl.status === 'VALID' && contactValue !== contactTypeControl.value) {
           this.contactTypeForm.controls['uniqueContact'].setValue('');
           this.vaidateUserContact();
           contactValue = contactTypeControl.value;
+        } else {
+            this.showUniqueError = '';
         }
       });
   }


### PR DESCRIPTION
In edit contact scenario variable "showUniqueError" is being updated only once and due to this error messages are not getting displayed as expected in few scenarios like:

Scenario 1: User enters 10 digit mobile no which is already associated with some other user and removes one or more digits.
Expected result: Only one error message related to valid mobile no should be displayed.
Actual result: Two error messages are getting displayed. One error is related to valid mobile no and second is related to uniqueness of mobile no.

Scenario 2: User enters 10 digit mobile no which is already associated with some other user and removes one or more digits. After removing the digits user clicks somewhere outside the input box.
Expected result: Only one error message related to valid mobile no should be displayed.
Actual result: Initially two error messages are getting displayed. One error is related to valid mobile no and second is related to uniqueness of mobile no. Once user clicks somewhere outside the input box, error message related to uniqueness of mobile no is getting disappeared.