### PR TITLE
Issue #SB-18865 fix: Course 'Leave Training' button disabled

### DIFF
--- a/src/app/client/src/app/modules/learn/components/batch/batch-details/batch-details.component.ts
+++ b/src/app/client/src/app/modules/learn/components/batch/batch-details/batch-details.component.ts
@@ -54,7 +54,7 @@ export class BatchDetailsComponent implements OnInit, OnDestroy {
     } else {
       return;
     }
-    if ((!this.enrolledBatchInfo.endDate) || (this.enrolledBatchInfo.endDate >= this.todayDate ) &&
+    if ((!this.enrolledBatchInfo.endDate || (this.enrolledBatchInfo.endDate >= this.todayDate)) &&
     this.enrolledBatchInfo.enrollmentType === 'open' && this.progress !== 100) {
       this.isUnenrollbtnDisabled = false;
     }


### PR DESCRIPTION
1. The button will be disabled if course progress is 100%
2. Enrollment type is `Open`
3. End date greater than today's date