### PR TITLE
Issue #SB-19308 Course QR code search : Org name is not displayed whe…

### DIFF
--- a/src/app/client/src/app/modules/shared/components/card/card.component.html
+++ b/src/app/client/src/app/modules/shared/components/card/card.component.html
@@ -59,7 +59,7 @@
 
     <!--Org-->
     <div class="sb-card-org ellipsis">
-      {{data.orgDetails?.orgName}}
+      {{data.orgDetails?.orgName ? data.orgDetails?.orgName : data?.organisation}}
     </div>
     <!--Org-->
 


### PR DESCRIPTION
…n the user search a course by using QR code