### PR TITLE
Issue #SB-17622 fix: Added telemetry Clicking on TOC from Library page

### DIFF
--- a/src/app/client/src/app/modules/public/module/player/components/public-collection-player/public-collection-player.component.html
+++ b/src/app/client/src/app/modules/public/module/player/components/public-collection-player/public-collection-player.component.html
@@ -59,7 +59,7 @@
           <div [hidden]="isSelectChapter" class="side-toc-content">
             <sb-toc-item [activeMimeTypeFilter]="activeMimeTypeFilter" [tocData]="collectionData"
               (tocCardClick)="tocCardClickHandler($event)" [activeContent]="activeContent"
-              (noContent)="showNoContent($event)"></sb-toc-item>
+              (noContent)="showNoContent($event)"  appTelemetryInteract [telemetryInteractEdata]="tocTelemetryInteractEdata"></sb-toc-item>
           </div>
           <div [hidden]="!isSelectChapter">
             <span>

--- a/src/app/client/src/app/modules/public/module/player/components/public-collection-player/public-collection-player.component.ts
+++ b/src/app/client/src/app/modules/public/module/player/components/public-collection-player/public-collection-player.component.ts
@@ -32,6 +32,7 @@ export class PublicCollectionPlayerComponent implements OnInit, OnDestroy, After
   telemetryShareData: Array<ITelemetryShare>;
   objectInteract: IInteractEventObject;
   printPdfInteractEdata: IInteractEventEdata;
+  tocTelemetryInteractEdata: IInteractEventEdata;
   shareLink: string;
   public sharelinkModal: boolean;
   public mimeType: string;
@@ -109,11 +110,6 @@ export class PublicCollectionPlayerComponent implements OnInit, OnDestroy, After
   playerOption: any;
   public playerContent;
   public unsubscribe$ = new Subject<void>();
-  telemetryInteractDataTocClick = {
-    id: 'toc-click',
-    type: 'click',
-    pageid: this.route.snapshot.data.telemetry.pageid
-  };
   selectedContent: {};
   pageId: string;
 
@@ -497,7 +493,15 @@ export class PublicCollectionPlayerComponent implements OnInit, OnDestroy, After
       this.initPlayer(_.get(this.activeContent, 'identifier'));
     }
   }
+  setTelemetryInteractData() {
+    this.tocTelemetryInteractEdata = {
+      id: 'library-toc',
+      type: 'click',
+      pageid: this.pageId
+    };
+  }
   tocCardClickHandler(event) {
+    this.setTelemetryInteractData();
     if (!this.isMobile && this.activeContent) {
       this.isMobile = true;
     }

--- a/src/app/client/src/app/modules/resource/modules/player/components/collection-player/collection-player.component.html
+++ b/src/app/client/src/app/modules/resource/modules/player/components/collection-player/collection-player.component.html
@@ -81,7 +81,7 @@
           <div [hidden]="isSelectChapter" class="main-side-toc-content">
             <sb-toc-item [activeMimeTypeFilter]="activeMimeTypeFilter" [tocData]="collectionData"
               (tocCardClick)="tocCardClickHandler($event)" [activeContent]="activeContent"
-              (noContent)="showNoContent($event)"></sb-toc-item>
+              (noContent)="showNoContent($event)" appTelemetryInteract [telemetryInteractEdata]="tocTelemetryInteractEdata"></sb-toc-item>
           </div>
           <div [hidden]="!isSelectChapter">
             <span>

--- a/src/app/client/src/app/modules/resource/modules/player/components/collection-player/collection-player.component.ts
+++ b/src/app/client/src/app/modules/resource/modules/player/components/collection-player/collection-player.component.ts
@@ -84,6 +84,8 @@ export class CollectionPlayerComponent implements OnInit, OnDestroy, AfterViewIn
 
   copyAsCourseInteractEdata: IInteractEventEdata;
 
+  tocTelemetryInteractEdata: IInteractEventEdata;
+
   private subscription: Subscription;
 
   public contentType: string;
@@ -116,11 +118,6 @@ export class CollectionPlayerComponent implements OnInit, OnDestroy, AfterViewIn
   public telemetryCdata: Array<{}>;
   selectedContent: {};
   public unsubscribe$ = new Subject<void>();
-  telemetryInteractDataTocClick = {
-    id: 'toc-click',
-    type: 'click',
-    pageid: this.route.snapshot.data.telemetry.pageid
-  };
   mimeTypeFilters;
   activeMimeTypeFilter;
   isContentPresent: Boolean = false;
@@ -446,8 +443,16 @@ export class CollectionPlayerComponent implements OnInit, OnDestroy, AfterViewIn
       this.initPlayer(_.get(this.activeContent, 'identifier'));
     }
   }
+  setTelemetryInteractData() {
+    this.tocTelemetryInteractEdata = {
+      id: 'library-toc',
+      type: 'click',
+      pageid: this.route.snapshot.data.telemetry.pageid
+    };
+  }
   tocCardClickHandler(event) {
     // console.log(event);
+    this.setTelemetryInteractData();
     this.callinitPlayer(event);
   }
   tocChapterClickHandler(event) {
@@ -487,7 +492,7 @@ export class CollectionPlayerComponent implements OnInit, OnDestroy, AfterViewIn
         this.toasterService.error(this.resourceService.messages.emsg.m0008);
       });
   }
-  
+
   /**
    * @since - #SH-66
    * @param  {ContentData} contentData


### PR DESCRIPTION
[Telemetry]: Clicking on TOC from Library page, edata.id is displayed as course-toc and also pageid: is been displayed as "course-read"