### PR TITLE
Issue #SH-273 fix: All contents are showing when moving to next page in draft and published after adding filters

### DIFF
--- a/src/app/client/src/app/modules/workspace/components/draft/draft.component.spec.ts
+++ b/src/app/client/src/app/modules/workspace/components/draft/draft.component.spec.ts
@@ -137,7 +137,8 @@ describe('DraftComponent', () => {
       component.pager.totalPages = 8;
       component.navigateToPage(1);
       fixture.detectChanges();
-      expect(route.navigate).toHaveBeenCalledWith(['workspace/content/draft', component.pageNumber]);
+      expect(route.navigate).toHaveBeenCalledWith(['workspace/content/draft', component.pageNumber],
+      { queryParams: component.queryParams });
     }));
 
   it('should call deleteConfirmModal method to delte the content', inject([],
@@ -205,7 +206,8 @@ describe('DraftComponent', () => {
       component.pager.totalPages = 8;
       component.navigateToPage(1);
       fixture.detectChanges();
-      expect(route.navigate).toHaveBeenCalledWith(['workspace/content/draft', component.pageNumber]);
+      expect(route.navigate).toHaveBeenCalledWith(['workspace/content/draft', component.pageNumber],
+      { queryParams: component.queryParams });
     }));
   xit('should fetch drafts list freshly if all contents are deleted from single page',
     inject([SuiModalService, ConfigService, Router, SearchService],

--- a/src/app/client/src/app/modules/workspace/components/draft/draft.component.ts
+++ b/src/app/client/src/app/modules/workspace/components/draft/draft.component.ts
@@ -325,7 +325,7 @@ export class DraftComponent extends WorkSpace implements OnInit, AfterViewInit {
             return;
         }
         this.pageNumber = page;
-        this.route.navigate(['workspace/content/draft', this.pageNumber]);
+        this.route.navigate(['workspace/content/draft', this.pageNumber], { queryParams: this.queryParams });
     }
 
     ngAfterViewInit () {

--- a/src/app/client/src/app/modules/workspace/components/published/published.component.spec.data.ts
+++ b/src/app/client/src/app/modules/workspace/components/published/published.component.spec.data.ts
@@ -110,5 +110,7 @@ export const mockRes = {
       uri: '',
       visits: []
     }
-  }
+  },
+  pager: { 'totalItems': 72, 'currentPage': 3, 'pageSize': 9, 'totalPages': 8,
+  'startPage': 1, 'endPage': 8, 'startIndex': 1, 'endIndex': 72, 'pages': [1, 2, 3, 4, 5]}
 };

--- a/src/app/client/src/app/modules/workspace/components/published/published.component.spec.ts
+++ b/src/app/client/src/app/modules/workspace/components/published/published.component.spec.ts
@@ -135,4 +135,17 @@ describe('PublishedComponent', () => {
     component.ngOnInit();
     expect(component.fetchPublishedContent).toHaveBeenCalledWith(9, 1, bothParams);
   });
+
+  it('should navigate to given pageNumber along with the filter if added', () => {
+      const route = TestBed.get(Router);
+      spyOn(route, 'navigate').and.stub();
+      component.pager = testData.pager;
+      const bothParams = { params: {pageNumber: 1}, queryParams: {subject: ['english', 'odia'], sort_by: 'lastUpdatedOn', sortType: 'asc'}};
+      component.queryParams = bothParams.queryParams ;
+      component.pageNumber = 1;
+      component.navigateToPage(1);
+      fixture.detectChanges();
+      expect(route.navigate).toHaveBeenCalledWith(['workspace/content/published', 1],
+      { queryParams: component.queryParams });
+    });
 });

--- a/src/app/client/src/app/modules/workspace/components/published/published.component.ts
+++ b/src/app/client/src/app/modules/workspace/components/published/published.component.ts
@@ -334,7 +334,7 @@ export class PublishedComponent extends WorkSpace implements OnInit, AfterViewIn
       return;
     }
     this.pageNumber = page;
-    this.route.navigate(['workspace/content/published', this.pageNumber]);
+    this.route.navigate(['workspace/content/published', this.pageNumber], { queryParams: this.queryParams });
   }
 
   ngAfterViewInit () {


### PR DESCRIPTION
**_NOTE:_**
1. **Fix**:  Added filters were moved out once the user goes to the next page 