### PR TITLE
Issue #SB-19441 fix: The label course is not displayed in my training section course

### DIFF
--- a/src/app/client/src/app/modules/shared/services/config/app.config.json
+++ b/src/app/client/src/app/modules/shared/services/config/app.config.json
@@ -396,7 +396,8 @@
       },
       "dynamicFields": {
         "maxCount": "leafNodesCount",
-        "progress": "progress"
+        "progress": "progress",
+        "ribbon.right.name": "content.contentType"
       }
     }
   },


### PR DESCRIPTION
The label course is not displayed in my training section course alone