### PR TITLE
Issue #SB-3190 fix: Removing component caching for player related components

### DIFF
--- a/src/app/client/src/app/modules/learn/course-consumption-routing.module.ts
+++ b/src/app/client/src/app/modules/learn/course-consumption-routing.module.ts
@@ -41,10 +41,10 @@ const routes: Routes = [
       {
         path: ':courseId/batch/:batchId', component: CoursePlayerComponent,
         data: {
-          routeReuse: {
-            reuse: true,
-            path: 'learn/course/play'
-          },
+          // routeReuse: {
+          //   reuse: true,
+          //   path: 'learn/course/play'
+          // },
           telemetry: { env: telemetryEnv, pageid: 'course-read', type: 'workflow', object: { ver: '1.0', type: 'course' } },
           breadcrumbs: [{ label: 'Home', url: '/home' }, { label: 'Courses', url: '/learn' }]
         },

--- a/src/app/client/src/app/modules/public/module/player/player-routing.module.ts
+++ b/src/app/client/src/app/modules/public/module/player/player-routing.module.ts
@@ -4,10 +4,10 @@ import { PublicCollectionPlayerComponent, PublicContentPlayerComponent } from '.
 const routes: Routes = [
     {
         path: 'content/:contentId', component: PublicContentPlayerComponent, data: {
-            routeReuse: {
-                reuse: true,
-                path: '/play/content'
-              },
+            // routeReuse: {
+            //     reuse: true,
+            //     path: '/play/content'
+            //   },
             telemetry: {
                 env: 'public', pageid: 'play-content', type: 'view', subtype: 'paginate'
             }
@@ -15,10 +15,10 @@ const routes: Routes = [
     },
     {
         path: 'collection/:collectionId', component: PublicCollectionPlayerComponent, data: {
-            routeReuse: {
-                reuse: true,
-                path: '/play/collection'
-              },
+            // routeReuse: {
+            //     reuse: true,
+            //     path: '/play/collection'
+            //   },
             telemetry: {
                 env: 'public', pageid: 'play-collection', type: 'view', subtype: 'paginate'
             }

--- a/src/app/client/src/app/modules/resource/modules/player/player-routing.module.ts
+++ b/src/app/client/src/app/modules/resource/modules/player/player-routing.module.ts
@@ -7,10 +7,10 @@ const routes: Routes = [
     {
         path: 'collection/:collectionId', component: CollectionPlayerComponent,
         data: {
-            routeReuse: {
-                reuse: true,
-                path: 'resources/play/collection'
-            },
+            // routeReuse: {
+            //     reuse: true,
+            //     path: 'resources/play/collection'
+            // },
             breadcrumbs: [{ label: 'Home', url: '/home' }, { label: 'Library', url: '' }],
             telemetry: { env: telemetryEnv, pageid: 'collection-player', type: 'play' }
         }
@@ -23,10 +23,10 @@ const routes: Routes = [
     }, {
         path: 'content/:contentId', component: ContentPlayerComponent,
         data: {
-            routeReuse: {
-                reuse: true,
-                path: 'resources/play/content'
-            },
+            // routeReuse: {
+            //     reuse: true,
+            //     path: 'resources/play/content'
+            // },
             telemetry: {
                 env: telemetryEnv, pageid: 'content-player', type: 'play'
             }, breadcrumbs: [{ label: 'Home', url: '/home' }, { label: 'Library', url: '/resources' }]


### PR DESCRIPTION
@vinukumar-vs  
Root cause: Collection player component is cached. Every time the collection player page is loaded cached component is preferred, if not available component instance is created by angular. ActivatedRoute.param is used to detect collection change and collection details are fetched if it's changed. As collection player component has many child component new textbook data should be pushed to all components including common consumption components. This process is handled by angular change detection. But this detection is not triggered for common consumption component. Due to this there some mismatches in child components. 

Fix: Removing component caching for player related components.

Reason: we added component caching in player page to load player faster. As player loads in Iframe every time cached component is used, iframe content is being reloaded. As collection player component is complex and has many child components, we need to make sure all child view is updated. If add any new component also this should be ensured. Hence due to these complexity am proposing to remove caching of player component.

We can enable this when player reload also works for all mime-types and we have proper design in place like (Behaviour subject or Redux to handle portal state). Please suggest if you have better approch. 