### PR TITLE
Issue #SB-29116 fix: Updated verification flow for t params in scanned URL

### DIFF
--- a/src/app/client/package.json
+++ b/src/app/client/package.json
@@ -49,7 +49,7 @@
     "@project-sunbird/chatbot-client-v8": "2.0.3",
     "@project-sunbird/ckeditor-build-classic": "4.1.3",
     "@project-sunbird/ckeditor-build-font": "^1.0.8",
-    "@project-sunbird/client-services": "4.8.10",
+    "@project-sunbird/client-services": "4.8.11",
     "@project-sunbird/common-consumption-v9": "4.7.1",
     "@project-sunbird/discussions-ui-v8": "2.6.0-beta.2",
     "@project-sunbird/sb-styles": "0.0.8",

--- a/src/app/client/yarn.lock
+++ b/src/app/client/yarn.lock
@@ -1782,10 +1782,10 @@
     "@ckeditor/ckeditor5-font" "^11.1.0"
     "@wiris/mathtype-ckeditor5" "^7.13.0"
 
-"@project-sunbird/client-services@4.8.10":
-  version "4.8.10"
-  resolved "https://registry.yarnpkg.com/@project-sunbird/client-services/-/client-services-4.8.10.tgz#971a50e89388582fccd7c60d3315ad3fae1060fa"
-  integrity sha512-OX66HWV1sc99+8DJH46v5Mom08p+7fu3KuaIfFHtVSXD5ejQcLh9e9DADkdbFXwczNq1+CG6kgLtu38UU/7ZTg==
+"@project-sunbird/client-services@4.8.11":
+  version "4.8.11"
+  resolved "https://registry.yarnpkg.com/@project-sunbird/client-services/-/client-services-4.8.11.tgz#bdf6236214486220189734299a6968ed1c4926bb"
+  integrity sha512-MLZPJCII/MPpeVSqlTpNfQcb+SGoWGSOTmLdnxzp+m4yFzOSl2h9NIVjyM0NYN8guMvihdHn1QdFPjl6t4lzsA==
   dependencies:
     "@project-sunbird/telemetry-sdk" "0.0.26"
     inversify "^5.0.1"

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "player",
   "author": "sunbird",
-  "version": "4.8.0",
+  "version": "4.8.5",
   "buildNumber": "1",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
- Issue #SB-29116 fix: Updated verification flow for ``t`` params in scanned URL
  - Ex: `certs/1-b8bcd7cb-ad60-4de5-9e64-22e1385f12bb?t=URL`
- Updated portal version to `4.8.5`