### PR TITLE
Issue #SB-29116 fix: RC workflow - API rule reverted for rc certificate v1 key

### DIFF
--- a/src/app/helpers/whitelistApis.js
+++ b/src/app/helpers/whitelistApis.js
@@ -598,8 +598,7 @@ const API_LIST = {
       checksNeeded: []
     },
     'learner/rc/certificate/v1/key/:id': {
-      checksNeeded: ['ROLE_CHECK'],
-      ROLE_CHECK: [ROLE.PUBLIC],
+      checksNeeded: [],
       description: 'RC API to validate scanned certificate'
     },
     


### PR DESCRIPTION
- Issue #SB-29116 fix: RC workflow - API rule reverted for rc certificate v1 key
  - `learner/rc/certificate/v1/key/:id`