### PR TITLE
Issue #SB-30547 When creating a batch, the t&c text has no appropriat…

### DIFF
--- a/src/app/client/src/app/modules/learn/components/batch/create-batch/create-batch.component.html
+++ b/src/app/client/src/app/modules/learn/components/batch/create-batch/create-batch.component.html
@@ -175,7 +175,7 @@
             <label class="d-flex flex-ai-center">
               <input type="checkbox" formControlName="tncCheck" role="checkbox" class="mr-8 cursor-pointer">
               <span class="font-weight-normal fnormal">
-                {{resourceService?.frmelmnts?.lbl?.agreeCourseToc | interpolate:'{instance}': instance }}<a
+                {{resourceService?.frmelmnts?.lbl?.agreeCourseToc | interpolate:'{instance}': instance }} <a
                   href="{{url}}/term-of-use.html#courseGuidelines" target="_blank"
                   class="sb-color-primary">{{resourceService?.frmelmnts?.lbl?.courseGuidelines}}</a></span>
             </label>


### PR DESCRIPTION
…e space after apostrophe in Terms