### PR TITLE
Issue #SB-31172 fix:Overflow of content in the observation items of observation details page

### DIFF
--- a/src/app/client/src/app/modules/observation/components/observation-details/observation-details.component.scss
+++ b/src/app/client/src/app/modules/observation/components/observation-details/observation-details.component.scss
@@ -47,3 +47,14 @@
 .white-space-wrap {
   text-overflow: ellipsis;
 }
+
+::ng-deep{
+  .sb-mat-accordion__title span{
+    line-break: anywhere;
+  }
+  
+  .sb-mat-accordion__title div{
+    display: flex;
+    align-items: inherit;
+  }
+}


### PR DESCRIPTION

# SunbirdEd - Portal
---
Overflow of text and other items in the observation form section of the observation details page when the title of the observation has many characters. 
Style fix has been done in this pull request.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
