### PR TITLE
Issue #ED-622 fix:Button labels case issue in edit pop up in observation details page

### DIFF
--- a/src/app/client/src/app/modules/observation/components/edit-submission/edit-submission.component.html
+++ b/src/app/client/src/app/modules/observation/components/edit-submission/edit-submission.component.html
@@ -16,12 +16,12 @@
             </mat-dialog-content>
             <mat-dialog-actions class="mb-0 sb-mat__modal__actions flex-jc-center">
                 <div class="sb-onboard__footer d-flex">
-                    <button type="button" class=" ui sb-btn sb-btn-sm sb-btn-white text-uppercase flex-basis-1" type="submit"
+                    <button type="button" class=" ui sb-btn sb-btn-sm sb-btn-white flex-basis-1" type="submit"
                         (click)="closeModal()">
                         {{editData?.leftBtnText}}
                     </button>
                     <div class="w-10"></div>
-                    <button type="button" class="ui sb-btn sb-btn-sm sb-btn-primary text-uppercase flex-basis-1" type="submit"
+                    <button type="button" class="ui sb-btn sb-btn-sm sb-btn-primary flex-basis-1" type="submit"
                         (click)="submit()" [disabled]="!updatedValue" [ngClass]="{'sb-btn-disabled' : !updatedValue}">
                         {{editData?.rightBtnText}}
                     </button>


### PR DESCRIPTION
# SunbirdEd - Portal
---
### Button labels case issue in edit pop up of observation details page.
---
### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
