### PR TITLE
Issue #ED-638 fix: Non-logged in user is taken to the login screen after clicking on observation tile of browse other categories

### DIFF
--- a/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.ts
+++ b/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.ts
@@ -1138,7 +1138,7 @@ export class ExplorePageComponent implements OnInit, OnDestroy, AfterViewInit {
                 this.router.navigate(['observation']);
             }
         }else{
-            window.location.href = '/resources';
+            window.location.href = '/observation';
         }
     }
 

--- a/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.ts
+++ b/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.ts
@@ -1137,6 +1137,8 @@ export class ExplorePageComponent implements OnInit, OnDestroy, AfterViewInit {
             if(pillData.name === 'observation'){
                 this.router.navigate(['observation']);
             }
+        }else{
+            window.location.href = '/resources';
         }
     }
 

--- a/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.ts
+++ b/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.ts
@@ -1138,7 +1138,7 @@ export class ExplorePageComponent implements OnInit, OnDestroy, AfterViewInit {
                 this.router.navigate(['observation']);
             }
         }else{
-            window.location.href = '/observation';
+            window.location.href = pillData.name === 'observation' ? '/observation': '/resources'
         }
     }
 


### PR DESCRIPTION


# SunbirdEd - Portal
---

### Non-logged in user is taken to the login screen after clicking on observation tile of browse other categories.
---

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
