### PR TITLE
Issues #ED-1515 Portal : Once user clicks on save template the pop up appear with 'X' icon distorted for the certificate creation and #ED-1516 Portal: When user clicks on Add report summary and Add chart summary getting popup with 'X' Icon distorted.

### DIFF
--- a/src/app/client/src/app/modules/certificate/components/certificate-configuration/certificate-configuration.component.html
+++ b/src/app/client/src/app/modules/certificate/components/certificate-configuration/certificate-configuration.component.html
@@ -362,7 +362,7 @@
     <div class="sb-mat__modal">
       <div mat-dialog-title class="mb-0">
         <div class="title" tabindex="0">{{resourceService?.frmelmnts?.cert?.lbl?.alertHeader}}</div>
-        <button aria-label="close dialog" mat-dialog-close class="mat-close-btn"></button>
+        <button aria-label="close dialog" mat-dialog-close class="close-btn"></button>
       </div>
 
       <div class="sb-mat__modal__content">

--- a/src/app/client/src/app/modules/dashboard/components/add-summary-modal/add-summary-modal.component.html
+++ b/src/app/client/src/app/modules/dashboard/components/add-summary-modal/add-summary-modal.component.html
@@ -1,7 +1,7 @@
 <div class="sb-mat__modal sb-modal-addsummary">
   <div mat-dialog-title class="mb-0">
     <div class="title" tabindex="0">{{input?.title}}</div>
-    <button aria-label="close dialog" mat-dialog-close class="mat-close-btn"></button>
+    <button aria-label="close dialog" mat-dialog-close class="close-btn"></button>
   </div>
 
   <div class="sb-mat__modal__content o-x-hide">

--- a/src/app/client/src/app/modules/dashboard/components/course-progress/course-progress.component.html
+++ b/src/app/client/src/app/modules/dashboard/components/course-progress/course-progress.component.html
@@ -6,7 +6,7 @@
       <!-- Download report popup-->
       <div mat-dialog-title class="mb-0">
         <div class="title" tabindex="0">{{resourceService?.frmelmnts?.instn?.t0060}}</div>
-        <button aria-label="close dialog" mat-dialog-close class="mat-close-btn"></button>
+        <button aria-label="close dialog" mat-dialog-close class="close-btn"></button>
       </div>
 
       <!--/Header-->

--- a/src/app/client/src/app/modules/dashboard/components/organization/organization.component.html
+++ b/src/app/client/src/app/modules/dashboard/components/organization/organization.component.html
@@ -154,7 +154,7 @@
               <!--Header-->
               <div mat-dialog-title class="mb-0">
                 <div class="title" tabindex="0">{{resourceService?.frmelmnts?.instn?.t0060}}</div>
-                <button aria-label="close dialog" mat-dialog-close class="mat-close-btn"></button>
+                <button aria-label="close dialog" mat-dialog-close class="close-btn"></button>
               </div>
               <!--/Header-->
               <!--Content-->


### PR DESCRIPTION
# SunbirdEd - Portal
---

### Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
---

### Please choose applicable option 
#### Example
- [x] Applicable
- [ ] Not applicable

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
