### PR TITLE
Changed incorrect link to staging app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Project Sunbird is an [open, iterative and collaborative](http://www.sunbird.org
 The Sunbird portal is the browser-based interface for the Sunbird application stack. It provides a web-app through which all functionality of Sunbird can be accessed.
 
 ## Getting started
-To get started with the Sunbird portal, please try out our cloud-based demo site at: https://staging.open-sunbird.org/
+To get started with the Sunbird portal, please try out our cloud-based demo site at: https://staging.sunbirded.org/
 
 ### Local Installation
 You can also install the Sunbird portal locally on your laptop, please follow the instructions below:


### PR DESCRIPTION
# SunbirdEd - Portal
---

### Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
---
The link to staging app in Readme was  https://staging.open-sunbird.org/ , which does  not work . Instead , updated the link to https://staging.sunbirded.org/ . 
Fixes issue #8770 

### Please choose applicable option 
#### Example
- [] Applicable
- [x] Not applicable

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
