### PR TITLE
fixes The link to staging app in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Project Sunbird is an [open, iterative and collaborative](http://www.sunbird.org
 The Sunbird portal is the browser-based interface for the Sunbird application stack. It provides a web-app through which all functionality of Sunbird can be accessed.
 
 ## Getting started
-To get started with the Sunbird portal, please try out our cloud-based demo site at: https://staging.open-sunbird.org/
+To get started with the Sunbird portal, please try out our cloud-based demo site at: https://staging.sunbirded.org/
 
 ### Local Installation
 You can also install the Sunbird portal locally on your laptop, please follow the instructions below:


### PR DESCRIPTION
# SunbirdEd - Portal
---

### The link to staging app in Readme was https://staging.open-sunbird.org/ , which does not work . Instead , update the link to https://staging.sunbirded.org/ .
---
